### PR TITLE
Percentage may display infinity symbol

### DIFF
--- a/src/routes/optimizations/optimizationsBreakdown/optimizationsBreakdownConfiguration.tsx
+++ b/src/routes/optimizations/optimizationsBreakdown/optimizationsBreakdownConfiguration.tsx
@@ -160,8 +160,12 @@ const OptimizationsBreakdownConfiguration: React.FC<OptimizationsBreakdownConfig
     if (typeof oldNumber !== 'number' || typeof newNumber !== 'number') {
       return 0;
     }
+    if (oldNumber === 0) {
+      return 0;
+    }
     const changeValue = newNumber - oldNumber;
-    return (changeValue / oldNumber) * 100;
+    const test = (changeValue / oldNumber) * 100;
+    return test;
   };
 
   const getRecommendedActions = () => {
@@ -275,10 +279,11 @@ const OptimizationsBreakdownConfiguration: React.FC<OptimizationsBreakdownConfig
 
     // Calculate percentage change
     const percentage = getPercentage(currentVal, recommendedVal);
-    return intl.formatMessage(messages.percentPlus, {
+    const test = intl.formatMessage(messages.percentPlus, {
       count: percentage > 0 ? 1 : 0,
       value: formatPercentage(percentage),
     });
+    return test;
   };
 
   const getVariationConfig = config => {


### PR DESCRIPTION
Percentage may display infinity symbol. This ensures the UI displays a zero value.

https://issues.redhat.com/browse/COST-5296

![Screenshot 2024-07-18 at 10 55 53 AM](https://github.com/user-attachments/assets/6d4c57dc-17ca-4ad7-9fe8-7ca911da424c)
