### PR TITLE
Current prop

### DIFF
--- a/src/routes/components/resourceTypeahead/resourceInput.tsx
+++ b/src/routes/components/resourceTypeahead/resourceInput.tsx
@@ -50,7 +50,7 @@ const ResourceInput: React.FC<ResourceInputProps> = ({
 
   // apply focus to the text input
   const focusTextInput = () => {
-    textInputGroupRef.current.querySelector('input').focus();
+    textInputGroupRef?.current.querySelector('input').focus();
   };
 
   const getInputGroup = () => {
@@ -149,9 +149,9 @@ const ResourceInput: React.FC<ResourceInputProps> = ({
   // Close menu when a click occurs outside the menu or text input group
   const handleOnPopperClick = event => {
     if (
-      menuRef.current &&
-      !menuRef.current.contains(event.target) &&
-      !textInputGroupRef.current.contains(event.target)
+      menuRef?.current &&
+      !menuRef?.current.contains(event.target) &&
+      !textInputGroupRef?.current.contains(event.target)
     ) {
       setIsOpen(false);
     }
@@ -171,7 +171,7 @@ const ResourceInput: React.FC<ResourceInputProps> = ({
       case 'ArrowUp':
       case 'ArrowDown':
         // Allow focus on the menu and navigate using the arrow keys
-        if (menuRef.current) {
+        if (menuRef?.current) {
           const firstElement = menuRef.current.querySelector('li > button:not(:disabled)');
           (firstElement as any)?.focus();
         }
@@ -186,7 +186,7 @@ const ResourceInput: React.FC<ResourceInputProps> = ({
     <Popper
       trigger={getInputGroup()}
       popper={getMenu()}
-      appendTo={() => textInputGroupRef.current}
+      appendTo={() => textInputGroupRef?.current}
       isVisible={isOpen}
       onDocumentClick={handleOnPopperClick}
     />

--- a/src/routes/optimizations/optimizationsBreakdown/optimizationsBreakdownChart.tsx
+++ b/src/routes/optimizations/optimizationsBreakdown/optimizationsBreakdownChart.tsx
@@ -279,7 +279,7 @@ const OptimizationsBreakdownChart: React.FC<OptimizationsBreakdownChartProps> = 
   };
 
   const handleOnResize = () => {
-    const { clientWidth = 0 } = containerRef.current || {};
+    const { clientWidth = 0 } = containerRef?.current || {};
 
     if (clientWidth !== width) {
       setWidth(clientWidth);
@@ -400,7 +400,7 @@ const OptimizationsBreakdownChart: React.FC<OptimizationsBreakdownChartProps> = 
   }, [limitData, requestData, usageData]);
 
   useEffect(() => {
-    const unobserve = getResizeObserver(containerRef.current, handleOnResize);
+    const unobserve = getResizeObserver(containerRef?.current, handleOnResize);
     return () => {
       if (unobserve) {
         unobserve();

--- a/src/utils/chrome.tsx
+++ b/src/utils/chrome.tsx
@@ -32,7 +32,7 @@ export const withChrome = Component => {
 
     useLayoutEffect(() => {
       isOrgAdmin(auth).then(val => {
-        if (isMounted.current) {
+        if (isMounted?.current) {
           setOrgAdmin(val);
           setInitialized(true);
         }

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -26,7 +26,7 @@ export const useStateCallback = <T>(initialState: T): [T, (state: T, cb?: (_stat
   useEffect(() => {
     // cb.current is `undefined` on initial render,
     // so we only invoke callback on state *updates*
-    if (cbRef.current) {
+    if (cbRef?.current) {
       cbRef.current(state);
       cbRef.current = undefined; // reset callback after execution
     }


### PR DESCRIPTION
The token refresh issue below shows an "u.current is null" error somewhere in Cost Management. This will ensure we check the `current` prop for any refs.

Error
<img width="673" alt="Screenshot 2024-09-28 at 1 35 17 PM" src="https://github.com/user-attachments/assets/0075be5d-f734-45e1-a7e5-0074a1bde099">

Slack
https://redhat-internal.slack.com/archives/C023VGW21NU/p1727158886930129

Token refresh issue
https://issues.redhat.com/browse/RHINENG-10155

Token refresh PR
https://github.com/RedHatInsights/insights-chrome/pull/2945