### PR TITLE
Migrate frontend-components-notifications to v6.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@patternfly/react-table": "6.2.0",
         "@patternfly/react-tokens": "6.2.0",
         "@redhat-cloud-services/frontend-components": "^6.0.7",
-        "@redhat-cloud-services/frontend-components-notifications": "^5.0.7",
+        "@redhat-cloud-services/frontend-components-notifications": "^6.0.0",
         "@redhat-cloud-services/frontend-components-translations": "^4.0.4",
         "@redhat-cloud-services/frontend-components-utilities": "^6.0.5",
         "@reduxjs/toolkit": "^2.8.2",
@@ -2117,23 +2117,19 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-notifications": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-notifications/-/frontend-components-notifications-5.0.7.tgz",
-      "integrity": "sha512-CCkioaXuz/gCK4qbBOIEle14C2EM1Qj77uyEnD0m0zpF68VRAT1xDIUO6eWFpWGTbSpklLy/Iz+5iGcSDIBxuw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-notifications/-/frontend-components-notifications-6.0.0.tgz",
+      "integrity": "sha512-FMNOAaTQz48R2D1wRjS0bb9/cMnyu++mweSDpWQ8vFRzvsgoOJXxNNOI6+bJpN6FOgP637rI7tiquWd2QLv+Aw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@redhat-cloud-services/frontend-components": "^6.0.0",
-        "@redhat-cloud-services/frontend-components-utilities": "^6.0.0",
-        "redux-promise-middleware": "6.1.3"
+        "@redhat-cloud-services/frontend-components-utilities": "^6.0.0"
       },
       "peerDependencies": {
         "@patternfly/react-core": "^6.0.0",
         "@patternfly/react-icons": "^6.0.0",
-        "prop-types": "^15.6.2",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "react-redux": "^7.2.9 || ^8.0.0 || ^9.0.0",
-        "redux": ">=4.2.0"
+        "react-dom": "^18.2.0"
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-translations": {
@@ -12267,15 +12263,6 @@
     "node_modules/redux": {
       "version": "5.0.1",
       "license": "MIT"
-    },
-    "node_modules/redux-promise-middleware": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/redux-promise-middleware/-/redux-promise-middleware-6.1.3.tgz",
-      "integrity": "sha512-B/Hi5Ct5d9y5d/KG0f6MZUXKA0nrQh5583mHCx13HY3Avte8KfpoRH/TB5QT6k/FcjT6JCxjv7jedymidy2A1A==",
-      "license": "MIT",
-      "peerDependencies": {
-        "redux": "^2.0.0 || ^3.0.0 || ^4.0.0"
-      }
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@patternfly/react-table": "6.2.0",
     "@patternfly/react-tokens": "6.2.0",
     "@redhat-cloud-services/frontend-components": "^6.0.7",
-    "@redhat-cloud-services/frontend-components-notifications": "^5.0.7",
+    "@redhat-cloud-services/frontend-components-notifications": "^6.0.0",
     "@redhat-cloud-services/frontend-components-translations": "^4.0.4",
     "@redhat-cloud-services/frontend-components-utilities": "^6.0.5",
     "@reduxjs/toolkit": "^2.8.2",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,9 +1,8 @@
 import './app.scss';
 
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
-import NotificationsPortal from '@redhat-cloud-services/frontend-components-notifications/NotificationPortal';
-import { notificationsReducer } from '@redhat-cloud-services/frontend-components-notifications/redux';
-import { getRegistry } from '@redhat-cloud-services/frontend-components-utilities/Registry';
+import NotificationsProvider from '@redhat-cloud-services/frontend-components-notifications/NotificationsProvider';
+import { createStore } from '@redhat-cloud-services/frontend-components-notifications/state';
 import React, { useEffect, useLayoutEffect } from 'react';
 import { invalidateSession } from 'utils/sessionStorage';
 
@@ -13,11 +12,9 @@ import { Routes } from './routes';
 
 const App = () => {
   const { updateDocumentTitle } = useChrome();
+  const store = createStore();
 
   useEffect(() => {
-    const registry = getRegistry();
-    registry.register({ notifications: notificationsReducer as any });
-
     // You can use directly the name of your app
     updateDocumentTitle(pkg.insights.appname);
   }, []);
@@ -37,8 +34,9 @@ const App = () => {
 
   return (
     <div>
-      <NotificationsPortal />
-      <Routes />
+      <NotificationsProvider store={store}>
+        <Routes />
+      </NotificationsProvider>
     </div>
   );
 };

--- a/src/store/accountSettings/__snapshots__/accountSettings.test.ts.snap
+++ b/src/store/accountSettings/__snapshots__/accountSettings.test.ts.snap
@@ -4,6 +4,7 @@ exports[`default state 1`] = `
 {
   "byId": Map {},
   "errors": Map {},
+  "notification": Map {},
   "status": Map {},
 }
 `;

--- a/src/store/accountSettings/accountSettingsActions.ts
+++ b/src/store/accountSettings/accountSettingsActions.ts
@@ -1,5 +1,4 @@
 import { AlertVariant } from '@patternfly/react-core';
-import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import type { AccountSettings, AccountSettingsPayload, AccountSettingsType } from 'api/accountSettings';
 import {
   fetchAccountSettings as apiFetchAccountSettings,
@@ -23,6 +22,7 @@ import {
 
 interface AccountSettingsActionMeta {
   fetchId: string;
+  notification?: any;
 }
 
 export const fetchAccountSettingsRequest = createAction('settings/fetch/request')<AccountSettingsActionMeta>();
@@ -89,24 +89,28 @@ export function updateAccountSettings(settingsType: AccountSettingsType, payload
 
     return apiUpdateAccountSettings(settingsType, payload)
       .then(res => {
-        dispatch(updateAccountSettingsSuccess(res, meta));
         dispatch(
-          addNotification({
-            title: intl.formatMessage(messages.settingsSuccessTitle),
-            description: intl.formatMessage(messages.settingsSuccessDesc),
-            variant: AlertVariant.success,
-            dismissable: true,
+          updateAccountSettingsSuccess(res, {
+            ...meta,
+            notification: {
+              description: intl.formatMessage(messages.settingsSuccessDesc),
+              dismissable: true,
+              title: intl.formatMessage(messages.settingsSuccessTitle),
+              variant: AlertVariant.success,
+            },
           })
         );
       })
       .catch(err => {
-        dispatch(updateAccountSettingsFailure(err, meta));
         dispatch(
-          addNotification({
-            title: intl.formatMessage(messages.settingsErrorTitle),
-            description: intl.formatMessage(messages.settingsErrorDesc),
-            variant: AlertVariant.danger,
-            dismissable: true,
+          updateAccountSettingsFailure(err, {
+            ...meta,
+            notification: {
+              description: intl.formatMessage(messages.settingsErrorDesc),
+              dismissable: true,
+              title: intl.formatMessage(messages.settingsErrorTitle),
+              variant: AlertVariant.danger,
+            },
           })
         );
       });

--- a/src/store/accountSettings/accountSettingsReducer.ts
+++ b/src/store/accountSettings/accountSettingsReducer.ts
@@ -18,12 +18,14 @@ import {
 export type AccountSettingsState = Readonly<{
   byId: Map<string, AccountSettings>;
   errors?: Map<string, AxiosError>;
+  notification?: Map<string, any>;
   status?: Map<string, FetchStatus>;
 }>;
 
 export const defaultState: AccountSettingsState = {
   byId: new Map(),
   errors: new Map(),
+  notification: new Map(),
   status: new Map(),
 };
 
@@ -71,8 +73,9 @@ export function accountSettingsReducer(state = defaultState, action: AccountSett
     case getType(updateAccountSettingsFailure):
       return {
         ...state,
-        status: new Map(state.status).set(action.meta.fetchId, FetchStatus.complete),
         errors: new Map(state.errors).set(action.meta.fetchId, action.payload),
+        notification: new Map(state.notification).set(action.meta.fetchId, action.meta.notification),
+        status: new Map(state.status).set(action.meta.fetchId, FetchStatus.complete),
       };
     case getType(updateAccountSettingsRequest):
       return {
@@ -82,8 +85,9 @@ export function accountSettingsReducer(state = defaultState, action: AccountSett
     case getType(updateAccountSettingsSuccess):
       return {
         ...state,
-        status: new Map(state.status).set(action.meta.fetchId, FetchStatus.complete),
         errors: new Map(state.errors).set(action.meta.fetchId, null),
+        notification: new Map(state.notification).set(action.meta.fetchId, action.meta.notification),
+        status: new Map(state.status).set(action.meta.fetchId, FetchStatus.complete),
       };
     default:
       return state;

--- a/src/store/accountSettings/accountSettingsSelectors.ts
+++ b/src/store/accountSettings/accountSettingsSelectors.ts
@@ -8,14 +8,17 @@ export const selectAccountSettingsState = (state: RootState) => state[stateKey];
 export const selectAccountSettings = (state: RootState, accountSettingsType: AccountSettingsType) =>
   selectAccountSettingsState(state).byId.get(getFetchId(accountSettingsType));
 
-export const selectAccountSettingsStatus = (state: RootState, accountSettingsType: AccountSettingsType) =>
-  selectAccountSettingsState(state)?.status.get(getFetchId(accountSettingsType));
-
 export const selectAccountSettingsError = (state: RootState, accountSettingsType: AccountSettingsType) =>
   selectAccountSettingsState(state)?.errors.get(getFetchId(accountSettingsType));
 
-export const selectAccountSettingsUpdateStatus = (state: RootState, accountSettingsType: AccountSettingsType) =>
+export const selectAccountSettingsStatus = (state: RootState, accountSettingsType: AccountSettingsType) =>
   selectAccountSettingsState(state)?.status.get(getFetchId(accountSettingsType));
 
 export const selectAccountSettingsUpdateError = (state: RootState, accountSettingsType: AccountSettingsType) =>
   selectAccountSettingsState(state)?.errors.get(getFetchId(accountSettingsType));
+
+export const selectAccountSettingsUpdateNotification = (state: RootState, accountSettingsType: AccountSettingsType) =>
+  selectAccountSettingsState(state)?.notification?.get(getFetchId(accountSettingsType));
+
+export const selectAccountSettingsUpdateStatus = (state: RootState, accountSettingsType: AccountSettingsType) =>
+  selectAccountSettingsState(state)?.status.get(getFetchId(accountSettingsType));

--- a/src/store/rootReducer.ts
+++ b/src/store/rootReducer.ts
@@ -1,4 +1,3 @@
-import { notificationsReducer } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import { combineReducers } from 'redux';
 import { accountSettingsReducer, accountSettingsStateKey } from 'store/accountSettings';
 import { forecastReducer, forecastStateKey } from 'store/forecasts';
@@ -24,5 +23,4 @@ export const rootReducer = combineReducers({
   [rosStateKey]: rosReducer,
   [uiStateKey]: uiReducer,
   [userAccessStateKey]: userAccessReducer,
-  notifications: notificationsReducer,
 });

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,4 +1,3 @@
-import { notificationsMiddleware } from '@redhat-cloud-services/frontend-components-notifications/notificationsMiddleware';
 import { configureStore as createStore } from '@reduxjs/toolkit';
 import { axiosInstance } from 'api';
 
@@ -13,7 +12,7 @@ export const middleware = getDefaultMiddleware =>
       ignoreActions: true,
       ignoreState: true,
     },
-  }).concat(notificationsMiddleware());
+  });
 
 export function configureStore(initialState: Partial<RootState>) {
   const store = createStore({


### PR DESCRIPTION
https://issues.redhat.com/browse/COST-6288

## Summary by Sourcery

Migrate the application to use frontend-components-notifications v6 by embedding notification payloads in Redux action metadata and state, replacing the registry/NotificationsPortal approach with NotificationsProvider, updating selectors, reducers, and snapshots accordingly

New Features:
- Expose update notifications in account settings meta and state, and add a selector to retrieve them

Enhancements:
- Embed success and error notifications in account settings update actions and reducer rather than dispatching ad-hoc notifications
- Replace legacy registry-based notifications and NotificationsPortal with the new NotificationsProvider in the app root

Build:
- Upgrade @redhat-cloud-services/frontend-components-notifications to v6.0.0

Tests:
- Update accountSettings snapshot tests to include notification field

Chores:
- Remove deprecated notifications middleware and reducer registration from store configuration