### PR TITLE
Frontend Operator Migration

### DIFF
--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/RedHatInsights/frontend-components/refs/heads/master/packages/config-utils/src/feo/spec/frontend-crd.schema.json
+---
 apiVersion: v1
 kind: Template
 metadata:
@@ -6,53 +8,64 @@ objects:
   - apiVersion: cloud.redhat.com/v1alpha1
     kind: Frontend
     metadata:
-      name: cost-management-mfe
+      name: 'cost-management-mfe'
     spec:
-      envName: ${ENV_NAME}
-      title: 'Cost Management microfrontend (MFE) with Module Federation'
-      deploymentRepo: https://github.com/project-koku/koku-ui-mfe
+      feoConfigEnabled: true
+      bundleSegments:
+        - segmentId: 'cost-management-mfe'
+          bundleId: 'staging'
+          position: 100
+          navItems:
+            - id: 'cost-management-mfe.nav'
+              title: 'Cost Management MFE'
+              expandable: true
+              routes:
+                - id: 'cost-management-mfe.ros'
+                  title: 'ROS'
+                  expandable: true
+                  routes:
+                    - id: 'cost-management-mfe.ros.badge'
+                      title: 'Optimizations badge'
+                      href: '/staging/cost-management/ros/optimizations/badge'
+                    - id: 'cost-management-mfe.ros.link'
+                      title: 'Optimizations link'
+                      href: '/staging/cost-management/ros/optimizations/link'
+                    - id: 'cost-management-mfe.ros.summary'
+                      title: 'Optimizations summary'
+                      href: "/staging/cost-management/ros/optimizations/summary"
+                    - id: 'cost-management-mfe.ros.table'
+                      title: 'Optimizations table'
+                      href: '/staging/cost-management/ros/optimizations/table'
+                    - id: 'cost-management-mfe.ros.details'
+                      title: 'Optimizations details'
+                      href: '/staging/cost-management/ros/optimizations/details'
+                    - id: 'cost-management-mfe.ros.breakdown'
+                      title: 'Optimizations breakdown'
+                      href: '/staging/cost-management/ros/optimizations/breakdown'
+                - id: 'cost-management-mfe.ocm'
+                  title: 'OCM'
+                  expandable: true
+                  routes:
+                    - id: 'cost-management-mfe.ocm.overview'
+                      title: 'Overview card'
+                      href: "/staging/cost-management/ocm/overview"
       API:
         versions:
           - v1
+      envName: ${ENV_NAME}
+      title: 'Cost Management microfrontend (MFE) with Module Federation'
+      deploymentRepo: https://github.com/project-koku/koku-ui-mfe
       frontend:
         paths:
-          - /apps/cost-management-mfe
+          - '/apps/cost-management-mfe'
       image: ${IMAGE}:${IMAGE_TAG}
-      navItems:
-        - title: ROS
-          expandable: true
-          routes:
-            - appId: 'cost-management-mfe'
-              title: 'Optimizations badge'
-              href: '/staging/cost-management/optimizations/badge'
-            - appId: 'cost-management-mfe'
-              title: 'Optimizations link'
-              href: '/staging/cost-management/optimizations/link'
-            - appId: 'cost-management-mfe'
-              title: 'Optimizations summary'
-              href: "/staging/cost-management/optimizations/summary"
-            - appId: 'cost-management-mfe'
-              title: 'Optimizations table'
-              href: '/staging/cost-management/optimizations/table'
-            - appId: 'cost-management-mfe'
-              title: 'Optimizations details'
-              href: '/staging/cost-management/optimizations/details'
-            - appId: 'cost-management-mfe'
-              title: 'Optimizations breakdown'
-              href: '/staging/cost-management/optimizations/breakdown'
-        - title: OCM
-          expandable: true
-          routes:
-            - appId: 'cost-management-mfe'
-              title: 'Overview card'
-              href: "/staging/cost-management/ocm/overview"
       module:
         manifestLocation: "/apps/cost-management-mfe/fed-mods.json"
         modules:
-          - id: "cost-management-mfe"
-            module: "./RootApp"
+          - id: 'cost-management-mfe'
+            module: './RootApp'
             routes:
-              - pathname: /staging/cost-management
+              - pathname: '/staging/cost-management'
 parameters:
   - name: ENV_NAME
     required: true


### PR DESCRIPTION
Frontend Operator Migration

https://issues.redhat.com/browse/COST-6157

## Summary by Sourcery

Enable Frontend Operator configuration for the cost-management microfrontend by migrating the Template to use the Frontend CRD fields, including YAML schema annotation, feoConfigEnabled flag, and bundleSegments with detailed navigation routes.

New Features:
- Add YAML schema annotation for the Frontend CRD to improve IDE support
- Enable feoConfig and define bundleSegments with nested navigation items and routes for the cost-management microfrontend

Enhancements:
- Restructure the Template spec to move envName, title, and deploymentRepo under the API section and apply consistent quoting