### PR TITLE
Rebrand from insights to lightspeed

### DIFF
--- a/src/routes/components/page/notConfigured/notConfiguredState.tsx
+++ b/src/routes/components/page/notConfigured/notConfiguredState.tsx
@@ -34,7 +34,7 @@ const NotConfiguredState: React.FC<NotConfiguredStateProps> = () => {
         isCode
         toggleAriaLabel={intl.formatMessage(messages.copyToClipboard)}
       >
-        insights_cost_management_optimizations="true"
+        cost_management_optimizations="true"
       </ClipboardCopy>
     );
   };


### PR DESCRIPTION
Rebrand from insights to lightspeed

https://issues.redhat.com/browse/COST-6563

## Summary by Sourcery

Enhancements:
- Rename feature toggle attribute from insights_cost_management_optimizations to cost_management_optimizations