### PR TITLE
CPU utilization chart not displaying correctly

### DIFF
--- a/src/routes/components/charts/common/chartUtils.ts
+++ b/src/routes/components/charts/common/chartUtils.ts
@@ -52,7 +52,7 @@ export const getDomain = (series: ChartSeries[], hiddenSeries: Set<number>, grou
     }
     series.forEach((s: any, index) => {
       if (!isSeriesHidden(hiddenSeries, index) && s.data && s.data.length !== 0) {
-        const { max, min } = getMaxMinValues(s.data);
+        const { max = null, min = null } = getMaxMinValues(s.data);
         if ((maxValue === null || max > maxValue) && max !== null) {
           maxValue = max;
         }


### PR DESCRIPTION
Need to adjust the algorithm to calculate the chart's domain.

https://issues.redhat.com/browse/RHINENG-16431

**After**
<img width="964" height="466" alt="Screenshot 2025-09-18 at 1 54 20 PM" src="https://github.com/user-attachments/assets/528dce66-8948-4648-95b7-ae7722f8a212" />

## Summary by Sourcery

Bug Fixes:
- Default max and min to null in getDomain’s destructuring to prevent undefined values from breaking the axis computation.